### PR TITLE
travis: Adopt recent Travis Ruby VM changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ notifications:
   recipients:
     - groonga-commit@lists.sourceforge.jp
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
+before_install:
+  - gem update bundler


### PR DESCRIPTION
I've reflected recent Travis CI's Ruby VM image changes.

Should I drop support 1.9.3 in Travis?