### PR TITLE
Make it possible to use HTTPS

### DIFF
--- a/lib/groonga/client.rb
+++ b/lib/groonga/client.rb
@@ -78,6 +78,7 @@ module Groonga
       if protocol == :gqtp
         @connection = Groonga::Client::Protocol::GQTP.new(options)
       else
+        options[:use_ssl] = true if protocol == :https
         @connection = Groonga::Client::Protocol::HTTP.new(options)
       end
     end

--- a/lib/groonga/client.rb
+++ b/lib/groonga/client.rb
@@ -78,7 +78,7 @@ module Groonga
       if protocol == :gqtp
         @connection = Groonga::Client::Protocol::GQTP.new(options)
       else
-        options[:use_ssl] = true if protocol == :https
+        options[:use_tls] = true if protocol == :https
         @connection = Groonga::Client::Protocol::HTTP.new(options)
       end
     end

--- a/lib/groonga/client/protocol/http/synchronous.rb
+++ b/lib/groonga/client/protocol/http/synchronous.rb
@@ -34,7 +34,7 @@ module Groonga
 
           def send(command)
             begin
-              Net::HTTP.start(@host, @port) do |http|
+              Net::HTTP.start(@host, @port, @options) do |http|
                 http.read_timeout = read_timeout
                 response = send_request(http, command)
                 case response

--- a/lib/groonga/client/protocol/http/synchronous.rb
+++ b/lib/groonga/client/protocol/http/synchronous.rb
@@ -34,7 +34,7 @@ module Groonga
 
           def send(command)
             begin
-              Net::HTTP.start(@host, @port, @options) do |http|
+              Net::HTTP.start(@host, @port, use_ssl: @options[:use_tls]) do |http|
                 http.read_timeout = read_timeout
                 response = send_request(http, command)
                 case response


### PR DESCRIPTION
Hi,

You know, now we can use HTTPS to connect to groonga-httpd(see http://groonga.org/docs/news.html#release-6-0-0).
Then, client library also should be able to do so, shouldn't it?