### PR TITLE
Url typo

### DIFF
--- a/lib/groonga/client.rb
+++ b/lib/groonga/client.rb
@@ -90,7 +90,7 @@ module Groonga
     def initialize(options={})
       options = self.class.default_options.merge(options)
       url = options[:url] || build_url(options)
-      url = URL.parse(url) unless url.is_a?(URI::Generic)
+      url = URI.parse(url) unless url.is_a?(URI::Generic)
       options[:url] = url
       options[:read_timeout] ||= Default::READ_TIMEOUT
 

--- a/test/test-client.rb
+++ b/test/test-client.rb
@@ -56,7 +56,7 @@ class TestClient < Test::Unit::TestCase
         url << "@"
       end
       url << "#{@address}:#{@port}"
-      {:url => URI.parse(url)}
+      {:url => url}
     end
 
     def open_client(&block)


### PR DESCRIPTION
Hi,

I fixed typo and test preparation to use auto conversion of groonga-client in testing in order to prevent regression.