### PR TITLE
Support slices for select command

### DIFF
--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -41,6 +41,8 @@ module Groonga
         attr_accessor :drilldowns
 
         # @return [::Hash<String, ::Array<::Hash<String, Object>>]
+        #
+        # @since 0.3.4
         attr_accessor :slices
 
         def body=(body)

--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -64,14 +64,14 @@ module Groonga
         def parse_body(body)
           if body.is_a?(::Array)
             @n_hits, @records = parse_match_records_v1(body.first)
-            body[1..-1].each do |record|
-              if record.is_a?(::Hash) &&
-                   record.first[1][1].none? {|key| key[0] == "_nsubrecs"}
-                @slices = parse_slices_v1(record)
-              else
-                @drilldowns = parse_drilldowns_v1([record])
-              end
+            if @command.slices.empty?
+              raw_slices = nil
+              raw_drilldowns = body[1..-1]
+            else
+              raw_slices, *raw_drilldowns = body[1..-1]
             end
+            @slices = parse_slices_v1(raw_slices)
+            @drilldowns = parse_drilldowns_v1(raw_drilldowns)
           else
             @n_hits, @records = parse_match_records_v3(body)
             @drilldowns = parse_drilldowns_v3(body["drilldowns"])

--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -1,5 +1,6 @@
 # Copyright (C) 2013-2016  Kouhei Sutou <kou@clear-code.com>
 # Copyright (C) 2013  Kosuke Asami
+# Copyright (C) 2016  Masafumi Yokoyama <yokoyama@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -79,7 +80,8 @@ module Groonga
             @slices = {}
             if body["slices"]
               body["slices"].each do |key, records|
-                @slices[key] = parse_match_records_v3(records)
+                n_hits, body = parse_match_records_v3(records)
+                @slices[key] = body
               end
             end
           end

--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -40,7 +40,7 @@ module Groonga
         #   Otherwise, `[drilldown1, drilldown2]` is returned.
         attr_accessor :drilldowns
 
-        # @return [::Hash<String, Groonga::Client::Response::Select>]
+        # @return [::Hash<String, ::Array<::Hash<String, Object>>]
         attr_accessor :slices
 
         def body=(body)

--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -154,15 +154,6 @@ module Groonga
           end
         end
 
-        def parse_slices_v1(raw_slices)
-          slices = {}
-          (raw_slices || {}).each do |key, slice_body|
-            n_hits, body = parse_match_records_v1(slice_body)
-            slices[key] = body
-          end
-          slices
-        end
-
         def parse_drilldowns_v3(raw_drilldowns)
           drilldowns = {}
           (raw_drilldowns || {}).each do |key, raw_drilldown|
@@ -170,6 +161,15 @@ module Groonga
             drilldowns[key] = Drilldown.new(key, n_hits, records)
           end
           drilldowns
+        end
+
+        def parse_slices_v1(raw_slices)
+          slices = {}
+          (raw_slices || {}).each do |key, slice_body|
+            n_hits, body = parse_match_records_v1(slice_body)
+            slices[key] = body
+          end
+          slices
         end
 
         def parse_slices_v3(raw_slices)

--- a/lib/groonga/client/response/select.rb
+++ b/lib/groonga/client/response/select.rb
@@ -39,6 +39,9 @@ module Groonga
         #   Otherwise, `[drilldown1, drilldown2]` is returned.
         attr_accessor :drilldowns
 
+        # @return [::Hash<String, Groonga::Client::Response::Select>]
+        attr_accessor :slices
+
         def body=(body)
           super(body)
           parse_body(body)
@@ -58,10 +61,27 @@ module Groonga
         def parse_body(body)
           if body.is_a?(::Array)
             @n_hits, @records = parse_match_records_v1(body.first)
-            @drilldowns = parse_drilldowns_v1(body[1..-1])
+            body[1..-1].each do |record|
+              if record.is_a?(::Hash) &&
+                   record.first[1][1].none? {|key| key[0] == "_nsubrecs"}
+                @slices = {}
+                record.each do |key, slice_body|
+                  n_hits, body = parse_match_records_v1(slice_body)
+                  @slices[key] = body
+                end
+              else
+                @drilldowns = parse_drilldowns_v1([record])
+              end
+            end
           else
             @n_hits, @records = parse_match_records_v3(body)
             @drilldowns = parse_drilldowns_v3(body["drilldowns"])
+            @slices = {}
+            if body["slices"]
+              body["slices"].each do |key, records|
+                @slices[key] = parse_match_records_v3(records)
+              end
+            end
           end
           body
         end

--- a/test/response/test-select-command-version1.rb
+++ b/test/response/test-select-command-version1.rb
@@ -1,5 +1,6 @@
 # Copyright (C) 2013-2016  Kouhei Sutou <kou@clear-code.com>
 # Copyright (C) 2013  Kosuke Asami
+# Copyright (C) 2016  Masafumi Yokoyama <yokoyama@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -313,6 +314,65 @@ class TestResponseSelectCommandVersion1 < Test::Unit::TestCase
           values[label] = yield(drilldown)
         end
         values
+      end
+    end
+
+    class TestSlices < self
+      def setup
+        pair_arguments = {
+          "slices[groonga].filter" => 'tag @ "groonga"',
+        }
+        @command = Groonga::Command::Select.new("select", pair_arguments)
+        @body = [
+          [
+            [3],
+            [
+              [
+                "_id",
+                "UInt32"
+              ],
+              [
+                "tag",
+                "ShortText"
+              ]
+            ],
+            [1, "groonga"],
+            [2, "rroonga"],
+            [3, "groonga"],
+          ],
+          {
+            "groonga" => [
+              [2],
+              [
+                [
+                  "_id",
+                  "UInt32"
+                ],
+                [
+                  "tag",
+                  "ShortText"
+                ]
+              ],
+              [1, "groonga"],
+              [3, "groonga"],
+            ]
+          }
+        ]
+      end
+
+      def test_slices
+        assert_equal({
+                       "groonga" => [
+                         {"_id" => 1, "tag" => "groonga"},
+                         {"_id" => 3, "tag" => "groonga"},
+                       ]
+                     },
+                     slices(@body))
+      end
+
+      private
+      def slices(body)
+        create_response(body).slices
       end
     end
   end

--- a/test/response/test-select-command-version3.rb
+++ b/test/response/test-select-command-version3.rb
@@ -1,5 +1,6 @@
 # Copyright (C) 2013-2016  Kouhei Sutou <kou@clear-code.com>
 # Copyright (C) 2013  Kosuke Asami
+# Copyright (C) 2016  Masafumi Yokoyama <yokoyama@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -276,6 +277,67 @@ class TestResponseSelectCommandVersion3 < Test::Unit::TestCase
           values[label] = yield(drilldown)
         end
         values
+      end
+    end
+
+    class TestSlices < self
+      def setup
+        pair_arguments = {
+          "slices[groonga].filter" => 'tag @ "groonga"',
+        }
+        @command = Groonga::Command::Select.new("select", pair_arguments)
+        @body = {
+          "n_hits" => 3,
+          "columns" => [
+            {
+              "name" => "_id",
+              "type" => "UInt32"
+            },
+            {
+              "name" => "tag",
+              "type" => "ShortText"
+            }
+          ],
+          "records" => [
+            [1, "groonga"],
+            [2, "rroonga"],
+            [3, "groonga"],
+          ],
+          "slices" => {
+            "groonga" => {
+              "n_hits" => 2,
+              "columns" => [
+                {
+                  "name" => "_id",
+                  "type" => "UInt32"
+                },
+                {
+                  "name" => "tag",
+                  "type" => "ShortText"
+                }
+              ],
+              "records" => [
+                [1, "groonga"],
+                [3, "groonga"],
+              ]
+            }
+          }
+        }
+      end
+
+      def test_slices
+        assert_equal({
+                       "groonga" => [
+                         {"_id" => 1, "tag" => "groonga"},
+                         {"_id" => 3, "tag" => "groonga"},
+                       ]
+                     },
+                     slices(@body))
+      end
+
+      private
+      def slices(body)
+        create_response(body).slices
       end
     end
   end


### PR DESCRIPTION
selectコマンドの`--slices`オプションに対応しました。

@kou Command version 1のときのdrilldownsとslicesの判別が難しく、以下のような複雑な実装しか思いつきませんでした。もっとよいやり方があれば教えてください。
https://github.com/ranguba/groonga-client/compare/support-slices?expand=1#diff-f4accec712c34ba68563424ae9e8b921R57