### PR TITLE
Support more Rubyish API

### DIFF
--- a/lib/groonga/client/request/select.rb
+++ b/lib/groonga/client/request/select.rb
@@ -220,7 +220,18 @@ module Groonga
           #   The new request with the given condition.
           #
           # @since 0.4.4
-          def between(column_name, min, min_border, max, max_border)
+          def between(column_name, min, *args, min_border: :include, max_border: :include)
+            case args.size
+            when 1
+              max = args[0]
+            when 2
+              min_border = args[0]
+              max = args[1]
+            when 3
+              min_border = args[0]
+              max = args[1]
+              max_border = args[2]
+            end
             parameter = FilterBetweenParameter.new(column_name,
                                                    min, min_border,
                                                    max, max_border)

--- a/test/request/test-select.rb
+++ b/test/request/test-select.rb
@@ -94,11 +94,13 @@ class TestRequestSelect < Test::Unit::TestCase
 
     sub_test_case("#between") do
       def between(column_name,
-                  min, min_border,
-                  max, max_border)
+                  min, *args,
+                  min_border: :include,
+                  max_border: :include)
         @request.filter.between(column_name,
-                                min, min_border,
-                                max, max_border).to_parameters
+                                min, *args,
+                                min_border: min_border,
+                                max_border: max_border).to_parameters
       end
 
       test("border") do
@@ -107,6 +109,39 @@ class TestRequestSelect < Test::Unit::TestCase
                        :filter => "between(ages, 2, \"include\", 29, \"exclude\")",
                      },
                      between("ages", 2, "include", 29, "exclude"))
+      end
+
+      test("min max") do
+        assert_equal({
+                       :table => "posts",
+                       :filter => "between(ages, 2, \"include\", 29, \"include\")",
+                     },
+                     between("ages", 2, 29))
+      end
+
+      sub_test_case("keyword parameters") do
+        test("full") do
+          assert_equal({
+                         :table => "posts",
+                         :filter => "between(ages, 2, \"include\", 29, \"exclude\")",
+                       },
+                       between("ages", 2, 29, min_border: :include, max_border: :exclude))
+        end
+
+        test("omit max_border") do
+          assert_equal({
+                         :table => "posts",
+                         :filter => "between(ages, 2, \"exclude\", 29, \"include\")",
+                       },
+                       between("ages", 2, 29, min_border: :exclude))
+        end
+        test("omit min_border") do
+          assert_equal({
+                         :table => "posts",
+                         :filter => "between(ages, 2, \"include\", 29, \"exclude\")",
+                       },
+                       between("ages", 2, 29, max_border: :exclude))
+        end
       end
     end
 


### PR DESCRIPTION
Add following API:

  * between(column, min, max)
  * between(column, min, max, min_border: :include, max_border: :include)

1st form is that we omit `min_border` and `max_border` in 2nd form.