### PR TITLE
response: parse: Include input JSON in Error, on JSON parsing errors

### DIFF
--- a/lib/groonga/client/error.rb
+++ b/lib/groonga/client/error.rb
@@ -18,5 +18,35 @@ module Groonga
   class Client
     class Error < StandardError
     end
+
+    class ErrorResponse < Error
+      attr_reader :response
+      def initialize(response)
+        @response = response
+        command = @response.command
+        status_code = @response.status_code
+        error_message = @response.error_message
+        message = "failed to execute: "
+        message << "#{command.command_name}: #{status_code}: "
+        message << "<#{error_message}>: "
+        message << command.to_command_format
+        super(message)
+      end
+    end
+
+    class InvalidResponse < Client::Error
+      attr_reader :command
+      attr_reader :raw_response
+      def initialize(command, raw_response, error_message)
+        @command = command
+        @raw_response = raw_response
+        message = +"invalid response: "
+        message << "#{command.command_name}: "
+        message << "#{error_message}: "
+        message << "<#{command.to_command_format}>: "
+        message << "<#{raw_response}>"
+        super(message)
+      end
+    end
   end
 end

--- a/lib/groonga/client/error.rb
+++ b/lib/groonga/client/error.rb
@@ -34,7 +34,7 @@ module Groonga
       end
     end
 
-    class InvalidResponse < Client::Error
+    class InvalidResponse < Error
       attr_reader :command
       attr_reader :raw_response
       def initialize(command, raw_response, error_message)

--- a/lib/groonga/client/request/error.rb
+++ b/lib/groonga/client/request/error.rb
@@ -19,23 +19,9 @@ require "groonga/client/error"
 module Groonga
   class Client
     module Request
-      class Error < Client::Error
-      end
-
-      class ErrorResponse < Error
-        attr_reader :response
-        def initialize(response)
-          @response = response
-          command = @response.command
-          status_code = @response.status_code
-          error_message = @response.error_message
-          message = "failed to execute: "
-          message << "#{command.command_name}: #{status_code}: "
-          message << "<#{error_message}>: "
-          message << command.to_command_format
-          super(message)
-        end
-      end
+      # For backward compatibility
+      Error = Client::Error
+      ErrorResponse = Client::ErrorResponse
     end
   end
 end

--- a/lib/groonga/client/response/base.rb
+++ b/lib/groonga/client/response/base.rb
@@ -71,11 +71,16 @@ module Groonga
             case command.output_type
             when :json
               callback = command["callback"]
+              json_parse = -> (json) do
+                JSON.parse(json)
+              rescue JSON::ParserError => err
+                raise err.exception("source=`#{json}`")
+              end
               if callback and
                   /\A#{Regexp.escape(callback)}\((.+)\);\z/ =~ raw_response
-                response = JSON.parse($1)
+                response = json_parse.call($1)
               else
-                response = JSON.parse(raw_response)
+                response = json_parse.call(raw_response)
               end
               if response.is_a?(::Array)
                 header, body = response

--- a/lib/groonga/client/response/error.rb
+++ b/lib/groonga/client/response/error.rb
@@ -14,7 +14,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-require "groonga/client/error"
 require "groonga/client/response/base"
 
 module Groonga
@@ -65,21 +64,6 @@ module Groonga
           else
             (header["error"] || {})["line"]
           end
-        end
-      end
-
-      class InvalidResponse < Client::Error
-        attr_reader :command
-        attr_reader :raw_response
-        def initialize(command, raw_response, error_message)
-          @command = command
-          @raw_response = raw_response
-          message = +"invalid response: "
-          message << "#{command.command_name}: "
-          message << "#{error_message}: "
-          message << command.to_command_format
-          message << ": <#{raw_response}>"
-          super(message)
         end
       end
     end

--- a/lib/groonga/client/response/error.rb
+++ b/lib/groonga/client/response/error.rb
@@ -14,6 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+require "groonga/client/error"
 require "groonga/client/response/base"
 
 module Groonga
@@ -64,6 +65,21 @@ module Groonga
           else
             (header["error"] || {})["line"]
           end
+        end
+      end
+
+      class InvalidResponse < Client::Error
+        attr_reader :command
+        attr_reader :raw_response
+        def initialize(command, raw_response, error_message)
+          @command = command
+          @raw_response = raw_response
+          message = +"invalid response: "
+          message << "#{command.command_name}: "
+          message << "#{error_message}: "
+          message << command.to_command_format
+          message << ": <#{raw_response}>"
+          super(message)
         end
       end
     end

--- a/test/response/test-base.rb
+++ b/test/response/test-base.rb
@@ -222,5 +222,19 @@ class TestResponseBase < Test::Unit::TestCase
       response = Groonga::Client::Response::Base.parse(command, raw_response)
       assert_equal(1396012478, response.body["start_time"])
     end
+
+    def test_invalid_json
+      command = Groonga::Command::Base.new("cancel")
+      raw_response = '["header", :{"return_code":-77}}'
+      err = assert_raise(Groonga::Client::Response::InvalidResponse) do
+        Groonga::Client::Response::Base.parse(command, raw_response)
+      end
+      error_message = <<~'MESSAGE'.chomp
+        invalid response: cancel: invalid JSON: unexpected token at ':{"return_code":-77}}': cancel: <["header", :{"return_code":-77}}>
+      MESSAGE
+      assert_equal(error_message, err.message)
+      assert_equal(command, err.command)
+      assert_equal(raw_response, err.raw_response)
+    end
   end
 end

--- a/test/response/test-base.rb
+++ b/test/response/test-base.rb
@@ -226,11 +226,11 @@ class TestResponseBase < Test::Unit::TestCase
     def test_invalid_json
       command = Groonga::Command::Base.new("cancel")
       raw_response = '["header", :{"return_code":-77}}'
-      err = assert_raise(Groonga::Client::Response::InvalidResponse) do
+      err = assert_raise(Groonga::Client::InvalidResponse) do
         Groonga::Client::Response::Base.parse(command, raw_response)
       end
       error_message = <<~'MESSAGE'.chomp
-        invalid response: cancel: invalid JSON: unexpected token at ':{"return_code":-77}}': cancel: <["header", :{"return_code":-77}}>
+        invalid response: cancel: invalid JSON: unexpected token at ':{"return_code":-77}}': <cancel>: <["header", :{"return_code":-77}}>
       MESSAGE
       assert_equal(error_message, err.message)
       assert_equal(command, err.command)

--- a/test/response/test-base.rb
+++ b/test/response/test-base.rb
@@ -226,15 +226,16 @@ class TestResponseBase < Test::Unit::TestCase
     def test_invalid_json
       command = Groonga::Command::Base.new("cancel")
       raw_response = '["header", :{"return_code":-77}}'
-      err = assert_raise(Groonga::Client::InvalidResponse) do
+      begin
+        JSON.parse(raw_response)
+      rescue JSON::ParserError => error
+        parse_error_message = "invalid JSON: #{error}"
+      end
+      error = Groonga::Client::InvalidResponse.new(command, raw_response, parse_error_message)
+
+      assert_raise(error) do
         Groonga::Client::Response::Base.parse(command, raw_response)
       end
-      error_message = <<~'MESSAGE'.chomp
-        invalid response: cancel: invalid JSON: unexpected token at ':{"return_code":-77}}': <cancel>: <["header", :{"return_code":-77}}>
-      MESSAGE
-      assert_equal(error_message, err.message)
-      assert_equal(command, err.command)
-      assert_equal(raw_response, err.raw_response)
     end
   end
 end


### PR DESCRIPTION
For example, when the input is `["header", :{"return_code":-77}}`, a parse error.
The error is then as follows.
```
`parse': unexpected token at ':{"return_code":-77}}' (JSON::ParserError)
```

Include the input JSON in the error since the error does not include the full input JSON, making it difficult to debug.